### PR TITLE
Abstract away dependance of AngleGyroCorrection on PIDSource

### DIFF
--- a/src/edu/nr/lib/AngleGyroCorrection.java
+++ b/src/edu/nr/lib/AngleGyroCorrection.java
@@ -1,14 +1,11 @@
 package edu.nr.lib;
 
 import edu.nr.lib.navx.NavX;
-import edu.wpi.first.wpilibj.PIDSource;
-import edu.wpi.first.wpilibj.PIDSourceType;
 
-public class AngleGyroCorrection extends GyroCorrection implements PIDSource
-{
+public class AngleGyroCorrection extends GyroCorrection {
+
 	private double initialAngle;
 	double goalAngle;
-	PIDSourceType type;
 	NavX navx;
 	
 	public AngleGyroCorrection(double angle, NavX navx) {
@@ -18,7 +15,6 @@ public class AngleGyroCorrection extends GyroCorrection implements PIDSource
 		this.navx = navx;
 		goalAngle = angle;
 		initialAngle = navx.getYaw(AngleUnit.DEGREE);
-		type = PIDSourceType.kDisplacement;
 	}
 	
 	public AngleGyroCorrection(double angle) {
@@ -42,21 +38,5 @@ public class AngleGyroCorrection extends GyroCorrection implements PIDSource
 	public void reset()
 	{
 		initialAngle = navx.getYaw(AngleUnit.DEGREE);
-	}
-
-	@Override
-	public void setPIDSourceType(PIDSourceType pidSource) {
-		type = pidSource;
-		
-	}
-
-	@Override
-	public PIDSourceType getPIDSourceType() {
-		return type;
-	}
-
-	@Override
-	public double pidGet() {
-		return getAngleErrorDegrees();
 	}
 }

--- a/src/edu/nr/lib/AngleGyroCorrectionSource.java
+++ b/src/edu/nr/lib/AngleGyroCorrectionSource.java
@@ -1,0 +1,43 @@
+package edu.nr.lib;
+
+import edu.nr.lib.navx.NavX;
+import edu.wpi.first.wpilibj.PIDSource;
+import edu.wpi.first.wpilibj.PIDSourceType;
+
+public class AngleGyroCorrectionSource extends AngleGyroCorrection implements PIDSource {
+
+	PIDSourceType type;
+	
+	public AngleGyroCorrectionSource(double angle, NavX navx) {
+		super(angle, navx);
+		type = PIDSourceType.kDisplacement;
+	}
+	
+	public AngleGyroCorrectionSource(double angle) {
+		super(angle);
+	}
+	
+	public AngleGyroCorrectionSource(NavX navx) {
+		super(navx);
+	}
+	
+	public AngleGyroCorrectionSource() {
+		super();
+	}
+	
+	@Override
+	public void setPIDSourceType(PIDSourceType pidSource) {
+		type = pidSource;
+		
+	}
+
+	@Override
+	public PIDSourceType getPIDSourceType() {
+		return type;
+	}
+
+	@Override
+	public double pidGet() {
+		return super.getAngleErrorDegrees();
+	}
+}

--- a/src/edu/nr/robotics/subsystems/drive/DriveAnglePIDCommand.java
+++ b/src/edu/nr/robotics/subsystems/drive/DriveAnglePIDCommand.java
@@ -1,6 +1,6 @@
 package edu.nr.robotics.subsystems.drive;
 
-import edu.nr.lib.AngleGyroCorrection;
+import edu.nr.lib.AngleGyroCorrectionSource;
 import edu.nr.lib.CMD;
 import edu.nr.lib.PID;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -41,7 +41,7 @@ public class DriveAnglePIDCommand extends CMD {
 
 	@Override
 	protected void onStart() {
-		pid = new PID(angle*0.001, 0.0005, 0.0001, new AngleGyroCorrection(), new AngleController());
+		pid = new PID(angle*0.001, 0.0005, 0.0001, new AngleGyroCorrectionSource(), new AngleController());
     	pid.enable();
     	pid.setSetpoint(angle);
 	}


### PR DESCRIPTION
In response to https://github.com/246overclocked/frc-java-junit-template/issues/16 I wanted to try myself and see whether it would be difficult to follow my suggestion of abstracting away the dependance on WPILib code. It turned out to be very simple, and now `PIDSource` is no longer required to unit test `AngleGyroCorrection`. Now the new `AngleGyroCorrectionSource` extends `PIDSource`, and makes use of `AngleGyroCorrection` for all of it's logic and calculations. This way, the code is refactored to the benefit of separation of concerns and means your unit tests only actually require the code you want to test, and no more. That was the design intention of not importing WPILib in the test classpath -- to force people to remove that dependency, which allows much better testing isolation and code quality assurance.

As you will notice, `ant test` still fails because of `TestNavX`, which extends `NavX` (which uses WPILib code). I wasn't sure what you were going for with `TestNavX`, but I would suggest doing something similar and either refactoring `TestNavX` or `NavX` itself to separate your wrapping logic and math from the WPILib/NavX library calls.
